### PR TITLE
Selection highlight, unsaved changes mark

### DIFF
--- a/src/MorphemeConnect/MorphemeConnect/Application/Application.h
+++ b/src/MorphemeConnect/MorphemeConnect/Application/Application.h
@@ -224,6 +224,9 @@ public:
 	{
 		bool m_load = false;
 		bool m_save = false;
+		int m_selectedAnimIdx = -1;
+		std::vector<BYTE> m_edited;
+
 		int m_targetAnimIdx = -1;
 		float m_lenMult = 1.f;
 		bool m_loadTae = false;
@@ -235,6 +238,8 @@ public:
 	{
 		bool m_load = false;
 		bool m_save = false;
+		int m_selectedTimeActIdx = -1;
+		std::vector<BYTE> m_edited;
 		int m_taeId = -1;
 		float m_lenght = 0.f;
 	} m_timeActEditorFlags;

--- a/src/MorphemeConnect/MorphemeConnect/EventTrackEditor/EventTrackEditor.cpp
+++ b/src/MorphemeConnect/MorphemeConnect/EventTrackEditor/EventTrackEditor.cpp
@@ -259,9 +259,10 @@ void EventTrackEditor::DeleteEvent(int track_idx, int event_idx)
 
 void EventTrackEditor::ReloadTracks()
 {
-    this->Clear();
+    this->m_eventTracks.clear();
+    this->SetEditedState(false);
 
-    if ((g_morphemeConnect.m_nmb.m_init == true) && (g_morphemeConnect.m_eventTrackEditorFlags.m_targetAnimIdx != -1))
+    if ((g_morphemeConnect.m_nmb.m_init) && (g_morphemeConnect.m_eventTrackEditorFlags.m_targetAnimIdx != -1))
     {
         bool found = false;
 
@@ -326,7 +327,19 @@ EventTrackEditor::EventTrackEditor()
 
 }
 
+void EventTrackEditor::SetEditedState(bool state)
+{
+    if (this->m_animIdx == -1)
+        return;
+
+    if (g_morphemeConnect.m_eventTrackEditorFlags.m_edited.size() > this->m_animIdx)
+        g_morphemeConnect.m_eventTrackEditorFlags.m_edited[this->m_animIdx] = state;
+    else
+        Debug::Panic("EventTrackEditor.cpp", "Out of bound read while setting edited state (idx=%d, size=%d)\n", this->m_animIdx, g_morphemeConnect.m_eventTrackEditorFlags.m_edited.size());
+}
+
 void EventTrackEditor::Clear()
 {
+    this->m_nodeSource = nullptr;
     this->m_eventTracks.clear();
 }

--- a/src/MorphemeConnect/MorphemeConnect/EventTrackEditor/EventTrackEditor.h
+++ b/src/MorphemeConnect/MorphemeConnect/EventTrackEditor/EventTrackEditor.h
@@ -38,6 +38,7 @@ struct EventTrackEditor
     NodeDef* m_nodeSource;
 
     int m_animIdx = -1;
+
     std::vector<EventTrack> m_eventTracks;
     int m_frameMin, m_frameMax;
     bool focused = false;
@@ -69,6 +70,7 @@ struct EventTrackEditor
     void DeleteEvent(int track_idx, int event_idx);
 
     void ReloadTracks();
+    void SetEditedState(bool state);
 
     void Clear();
 };

--- a/src/MorphemeConnect/MorphemeConnect/MorphemeConnect.h
+++ b/src/MorphemeConnect/MorphemeConnect/MorphemeConnect.h
@@ -1,6 +1,6 @@
 #pragma once
-#define APPNAME_W L"MorphemeConnect 1.0.31"
-#define APPNAME_A "MorphemeConnect 1.0.31"
+#define APPNAME_W L"MorphemeConnect 1.0.4"
+#define APPNAME_A "MorphemeConnect 1.0.4"
 
 #include "resource.h"
 #include <d3d11.h>

--- a/src/MorphemeConnect/MorphemeConnect/Scene/Camera/Camera.h
+++ b/src/MorphemeConnect/MorphemeConnect/Scene/Camera/Camera.h
@@ -3,11 +3,19 @@
 class Camera
 {
 public:
-	struct CameraSpeed
+	struct Settings
 	{
-		float m_zoomSpeed = 10.f;
-		float m_dragSpeed = 0.3f;
-	} m_speedParams;
+		struct CameraSpeed
+		{
+			float m_zoomSpeed = 10.f;
+			float m_dragSpeed = 0.3f;
+		} m_speedParams;
+
+		bool m_dragInvertX = true;
+		bool m_dragInvertY = false;
+		bool m_rotInvertX = false;
+		bool m_rotInvertY = false;
+	} m_settings;
 
 	DirectX::SimpleMath::Matrix m_proj;
 	DirectX::SimpleMath::Matrix m_view;

--- a/src/MorphemeConnect/MorphemeConnect/TimeActEditor/TimeActEditor.cpp
+++ b/src/MorphemeConnect/MorphemeConnect/TimeActEditor/TimeActEditor.cpp
@@ -164,20 +164,35 @@ void TimeActEditor::DeleteEvent(int group_idx, int event_idx)
 void TimeActEditor::ReloadTracks()
 {
 	this->m_tracks.clear();
+	this->SetEditedState(false);
 
-	for (size_t i = 0; i < this->m_source->m_taeData->m_eventGroupCount; i++)
+	if ((g_morphemeConnect.m_tae.m_init == true))
 	{
-		this->m_source->m_taeData->m_groups[i].m_event.clear();
+		for (size_t i = 0; i < this->m_source->m_taeData->m_eventGroupCount; i++)
+		{
+			this->m_source->m_taeData->m_groups[i].m_event.clear();
 
-		for (size_t j = 0; j < this->m_source->m_taeData->m_groups[i].m_count; j++)
-			this->m_source->m_taeData->m_groups[i].m_event.push_back(&this->m_source->m_taeData->m_events[this->m_source->m_taeData->m_groups[i].m_eventIndex[j]]);
-	}
+			for (size_t j = 0; j < this->m_source->m_taeData->m_groups[i].m_count; j++)
+				this->m_source->m_taeData->m_groups[i].m_event.push_back(&this->m_source->m_taeData->m_events[this->m_source->m_taeData->m_groups[i].m_eventIndex[j]]);
+		}
 
-	if (this->m_source->m_taeData->m_eventGroupCount > 0)
-	{
-		for (int j = 0; j < this->m_source->m_taeData->m_eventGroupCount; j++)
-			this->m_tracks.push_back(&this->m_source->m_taeData->m_groups[j]);
-	}
+		if (this->m_source->m_taeData->m_eventGroupCount > 0)
+		{
+			for (int j = 0; j < this->m_source->m_taeData->m_eventGroupCount; j++)
+				this->m_tracks.push_back(&this->m_source->m_taeData->m_groups[j]);
+		}
+	}	
+}
+
+void TimeActEditor::SetEditedState(bool state)
+{
+	if (this->m_taeIdx == -1)
+		return;
+
+	if (g_morphemeConnect.m_timeActEditorFlags.m_edited.size() > this->m_taeIdx)
+		g_morphemeConnect.m_timeActEditorFlags.m_edited[this->m_taeIdx] = state;
+	else
+		Debug::Panic("TimeActEditor.cpp", "Out of bound read while setting edited state (idx=%d, size=%d)\n", this->m_taeIdx, g_morphemeConnect.m_timeActEditorFlags.m_edited.size());
 }
 
 void TimeActEditor::Clear()

--- a/src/MorphemeConnect/MorphemeConnect/TimeActEditor/TimeActEditor.h
+++ b/src/MorphemeConnect/MorphemeConnect/TimeActEditor/TimeActEditor.h
@@ -36,6 +36,7 @@ struct TimeActEditor
 
     TimeAct* m_source;
 
+    int m_taeIdx = -1;
     std::vector<TimeActTrack> m_tracks;
     int m_frameMin, m_frameMax;
     bool focused = false;
@@ -67,6 +68,7 @@ struct TimeActEditor
     void DeleteEvent(int group_idx, int event_idx);
 
     void ReloadTracks();
+    void SetEditedState(bool state);
 
     void Clear();
 };

--- a/src/MorphemeConnect/MorphemeConnect/imsequencer/ImSequencer.cpp
+++ b/src/MorphemeConnect/MorphemeConnect/imsequencer/ImSequencer.cpp
@@ -1144,7 +1144,11 @@ namespace ImSequencer
                         //eventTrackEditor->Paste();
                     }
                 }
-                //
+
+                if ((movingTrack >= 0 && movingEvent >= 0))
+                {
+                    eventTrackEditor->SetEditedState(true);
+                }
             }
 
             ImGui::EndChildFrame();
@@ -2126,7 +2130,11 @@ namespace ImSequencer
                         //timeActEditor->Paste();
                     }
                 }
-                //
+                
+                if ((movingTrack >= 0 && movingEvent >= 0))
+                {
+                    timeActEditor->SetEditedState(true);
+                }
             }
 
             ImGui::EndChildFrame();


### PR DESCRIPTION
Currently selected items will now stay highlighted.
Unsaved EventTrack/TimeAct are now shown in the Animation/TimeAct list with an asterisk (*) before their name.
Added options to invert drag and rotation X/Y in the Preview window.